### PR TITLE
[prefix_trie] Fixed issue in matcher prefix trie lookup

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -233,6 +233,11 @@ bug_fixes:
 - area: http2
   change: |
     Update nghttp2 to resolve CVE-2024-30255 https://github.com/envoyproxy/envoy/security/advisories/GHSA-j654-3ccm-vfmm.
+- area: prefix_matcher_tree
+  change: |
+    Fixed issue in matcher prefix tree lookup.
+    The lookup did not function correctly when the prefix tree had overlapping prefixes.
+    For example: with prefixes ``/foo`` and ``/foo/bar``, it would have incorrectly said no prefix match for ``/foo/``.
 
 removed_config_or_runtime:
 # *Normally occurs at the end of the* :ref:`deprecation period <deprecated>`

--- a/source/common/common/utility.h
+++ b/source/common/common/utility.h
@@ -694,20 +694,19 @@ template <class Value> struct TrieLookupTable {
   Value findLongestPrefix(const char* key) const {
     const TrieEntry<Value>* current = &root_;
     const TrieEntry<Value>* result = nullptr;
-    while (uint8_t c = *key) {
-      if (current->value_) {
-        result = current;
-      }
 
+    while (uint8_t c = *key) {
       // https://github.com/facebook/mcrouter/blob/master/mcrouter/lib/fbi/cpp/Trie-inl.h#L126-L143
       current = current->entries_[c].get();
+
       if (current == nullptr) {
         return result ? result->value_ : nullptr;
+      } else if (current->value_) {
+        result = current;
       }
-
       key++;
     }
-    return current ? current->value_ : result->value_;
+    return result ? result->value_ : Value{};
   }
 
   TrieEntry<Value> root_;

--- a/source/common/common/utility.h
+++ b/source/common/common/utility.h
@@ -693,7 +693,7 @@ template <class Value> struct TrieLookupTable {
    */
   Value findLongestPrefix(const char* key) const {
     const TrieEntry<Value>* current = &root_;
-    const TrieEntry<Value>* result = nullptr;
+    const TrieEntry<Value>* result = current;
 
     while (uint8_t c = *key) {
       // https://github.com/facebook/mcrouter/blob/master/mcrouter/lib/fbi/cpp/Trie-inl.h#L126-L143
@@ -706,7 +706,7 @@ template <class Value> struct TrieLookupTable {
       }
       key++;
     }
-    return result ? result->value_ : Value{};
+    return result ? result->value_ : nullptr;
   }
 
   TrieEntry<Value> root_;

--- a/test/common/common/utility_test.cc
+++ b/test/common/common/utility_test.cc
@@ -1082,14 +1082,19 @@ TEST(TrieLookupTable, LongestPrefix) {
   const char* cstr_a = "a";
   const char* cstr_b = "b";
   const char* cstr_c = "c";
+  const char* cstr_d = "d";
 
   EXPECT_TRUE(trie.add("foo", cstr_a));
   EXPECT_TRUE(trie.add("bar", cstr_b));
   EXPECT_TRUE(trie.add("baro", cstr_c));
+  EXPECT_TRUE(trie.add("foo/bar", cstr_d));
 
   EXPECT_EQ(cstr_a, trie.find("foo"));
   EXPECT_EQ(cstr_a, trie.findLongestPrefix("foo"));
   EXPECT_EQ(cstr_a, trie.findLongestPrefix("foosball"));
+  EXPECT_EQ(cstr_a, trie.findLongestPrefix("foo/"));
+  EXPECT_EQ(cstr_d, trie.findLongestPrefix("foo/bar"));
+  EXPECT_EQ(cstr_d, trie.findLongestPrefix("foo/bar/zzz"));
 
   EXPECT_EQ(cstr_b, trie.find("bar"));
   EXPECT_EQ(cstr_b, trie.findLongestPrefix("bar"));


### PR DESCRIPTION
Commit Message: 
[[prefix_trie] Fixed issue in matcher prefix trie lookup](https://github.com/sergkir85/envoy/pull/1/commits/0e9ad18806ffca9cf47193b869abd98657751ee9)

Additional Description:
Lookup in matcher prefix tree does not lookup correctly in certain scenario. If trie contains two overlapped prefixes (eg "/foo" and "foo/bar") then the following path "/foo/" will not be matched to "/foo" and will be return 404 response code. 

Config snippet: 
```
      matcher:
        matcher_tree:
          input:
            name: request-headers
            typed_config:
              "@type": type.googleapis.com/envoy.type.matcher.v3.HttpRequestHeaderMatchInput
              header_name: :path
          prefix_match_map:
            map:                              
              "/foo":
                action:
                  name: route_foo
                  typed_config:
                    "@type": type.googleapis.com/envoy.config.route.v3.Route
                    match:
                      prefix: /
                    route:
                      cluster: service_10000
              "/foo/bar":
                action:
                  name: route_foo_abc
                  typed_config:
                    "@type": type.googleapis.com/envoy.config.route.v3.Route
                    match:
                      prefix: /
                    route:
                      cluster: service_20000
```

Risk Level: Low
Testing: unittests
Docs Changes: n/a
Release Notes: n/a
Platform Specific Features:
